### PR TITLE
Add Classpert RoR online courses catalog to Videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,11 @@ TBD
 
 TBD
 
+## Rails Videos
+*Rails online courses, screencasts, etc*
+
+* [List of 80 free and paid Ruby on Rails courses from top e-learning platforms](https://classpert.com/ruby-on-rails) - A directory of RoR online courses by Classpert - An online course search and comparison site with thousands of free online courses
+
 # Credits
 
 TravisCI validation code by [jondot](https://github.com/jondot). Origin: https://github.com/jondot/awesome-react-native


### PR DESCRIPTION
This commit adds Classpert to a new section called “Videos”, with a comprehensive selection of ~ 70 Ruby on Rails courses (free and paid) from top e-learning providers like Udemy, Coursera, Pluralsight,Treehouse, and Skillshare.